### PR TITLE
Add improved colors for the Command Palette

### DIFF
--- a/themes/theme-espresso-soda-light.json
+++ b/themes/theme-espresso-soda-light.json
@@ -544,9 +544,16 @@
     "editorCursor.foreground": "#000000",
     "editor.foreground": "#000000",
     "editorWhitespace.foreground": "#E0E0E0",
-    "editor.lineHighlightBackground": "#A5A5A526",
+    "editor.lineHighlightBackground": "#FAF2CA",
     "editor.selectionBackground": "#C2E8FF",
-    "editor.inactiveSelectionBackground": "#EDEDED"
+    "editor.inactiveSelectionBackground": "#EDEDED",
+    "list.focusHighlightForeground": "#6700B9",
+    "quickInputList.focusBackground": "#FAF2CA",
+    "quickInputList.focusForeground": "#7653C1",
+    "editorSuggestWidget.focusHighlightForeground": "#6700B9",
+    "editorSuggestWidget.highlightForeground": "#7653C1",
+    "editorSuggestWidget.selectedForeground": "#7653C1",
+    "editorSuggestWidget.selectedBackground": "#B8E9FF"
   },
   "name": "Espresso Soda"
 }


### PR DESCRIPTION
Since Visual Studio Code version 1.57.1, it seems that the Command Palette and Intellisense colors became hard to read when using the Espresso Soda theme.

Please see the following screenshots:

<img width="173" alt="Screenshot 2021-06-22 at 17 42 16" src="https://user-images.githubusercontent.com/932365/122962868-1cf79c80-d386-11eb-814f-2f7c0284ed75.png">

<img width="621" alt="Screenshot 2021-06-22 at 17 41 36" src="https://user-images.githubusercontent.com/932365/122962860-1b2dd900-d386-11eb-9d62-e046302f8eb0.png">

-----

I improved this by adding extra colors for the `quickInputList` and `editorSuggestWidget` colors properties in `themes/theme-espresso-soda-light.json`.

The new colors look like this:
<img width="167" alt="Screenshot 2021-06-22 at 18 13 01" src="https://user-images.githubusercontent.com/932365/122963079-3f89b580-d386-11eb-90a4-7c165d5f964e.png">
<img width="308" alt="Screenshot 2021-06-22 at 18 13 14" src="https://user-images.githubusercontent.com/932365/122963086-40224c00-d386-11eb-83cf-4e450764ace2.png">

Please merge (and/or adapt?) this Pull Request so my Command Palette & Intellisense becomes readable again :-)